### PR TITLE
Docker support and CLI improvements

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,17 @@
+{
+  "name": "knowledge-mcp",
+  "image": "mcr.microsoft.com/devcontainers/python:3.12",
+  "workspaceFolder": "/workspace",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
+  "mounts": ["source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind"],
+  "postCreateCommand": "apt-get update && apt-get install -y docker.io && pip install --no-cache-dir uv && uv pip install -e .",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "ms-python.vscode-pylance"
+      ]
+    }
+  },
+  "remoteUser": "root"
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+# knowledge-mcp Docker image
+# Run with: docker run -v ~/kb:/app/kb knowledge-mcp
+# Override: docker run -v ~/kb:/app/kb knowledge-mcp shell
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY . .
+
+# Use uv for much faster, lockfile-driven installs
+RUN pip install --no-cache-dir uv \
+    && uv pip install --system --no-cache -e .
+
+# Default: run MCP server with base dir /app/kb (override with: shell, create mykb, list, etc.)
+# Use the installed package via Python module so we don't depend on script PATH
+ENTRYPOINT ["python", "-m", "knowledge_mcp.cli", "--base", "/app/kb"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: "3.8"
+
+services:
+  knowledge-mcp:
+    build: .
+    container_name: knowledge-mcp
+    volumes:
+      - ~/kb:/app/kb   # edit this path to your host knowledge-base directory
+    working_dir: /app/kb
+    command: mcp   # default = run MCP server (override: shell, create mykb, list, etc.)

--- a/knowledge_mcp/cli.py
+++ b/knowledge_mcp/cli.py
@@ -265,14 +265,15 @@ def main():
     parser.add_argument(
         "-c", "--config",
         type=str,
-        default="config.yml", # Consider making default relative to project root if cli is run from there
-        help="Path to the configuration file (default: config.yml)",
+        default=None,
+        required=False,
+        help="Path to the configuration file (config.yaml). If --base is also provided, --config takes precedence.",
     )
     parser.add_argument(
         "--base", "--kb-dir",
         type=str,
         required=False,
-        help="Base directory containing config.yaml (makes --config optional)."
+        help="Base directory containing config.yaml (makes --config optional). If provided, config.yaml is expected at <base>/config.yaml.",
     )
 
     subparsers = parser.add_subparsers(dest="command", required=True, help='Available modes: mcp, shell')
@@ -294,10 +295,7 @@ def main():
     args = parser.parse_args()
 
     # Determine config_path based on --config and --base
-    if args.config and args.base:
-        # Prefer --config for backward compatibility
-        config_path = args.config
-    elif args.config:
+    if args.config:
         config_path = args.config
     elif args.base:
         from pathlib import Path


### PR DESCRIPTION
## Summary

This PR adds **Docker support** and **CLI enhancements** so that knowledge-mcp can be run reliably in containers and integrated with MCP clients (Claude Desktop, Cursor, Windsurf, etc.) that spawn or connect to Docker-based servers.

## Changes

### Docker

- **`Dockerfile`**  
  - Python 3.12-slim image, `uv` for installs, default `ENTRYPOINT` runs the MCP server with `--base /app/kb`.  
  - Supports overrides: `docker run ... knowledge-mcp shell`, `create mykb`, `list`, etc.

- **`docker-compose.yml`**  
  - Single service that builds the image, mounts a configurable host directory (e.g. `~/kb`) to `/app/kb`, and runs the MCP server by default.  
  - Documented for `docker compose up/down`, `run ... shell`, `run ... create`, `run ... list`.

- **`.devcontainer/devcontainer.json`**  
  - Dev container (Python 3.12) with Docker socket mount and `docker.io` + `uv` in `postCreateCommand`, so you can build/run the app and use Docker from inside the dev container.

### CLI (`knowledge_mcp/cli.py`)

- **`--base` (and `--kb-dir`) option**  
  - Accepts a directory that contains `config.yaml`; config is then loaded from `<base>/config.yaml`.  
  - Makes `--config` optional when using a standard layout (e.g. in Docker with `/app/kb`).

- **Argument order**  
  - `--config` and `--base` are pre-parsed so they can appear before the subcommand.  
  - Fixes invocations like `knowledge-mcp --base /app/kb shell` where `/app/kb` was previously consumed as the subcommand.

- **New subcommands**  
  - **`create <name> [description]`** – Create a knowledge base and initialize its RAG instance (one-off, useful in Docker).  
  - **`list`** – List all knowledge bases with optional descriptions (one-off, useful in Docker).

- **Config resolution**  
  - If both are given, `--config` wins; otherwise config is `Path(base) / "config.yaml"` when `--base` is set.  
  - Clear error if neither `--config` nor `--base` is provided.

- **User-facing error**  
  - When the first unknown argument looks like a path (contains `/` or `\`), print a hint to use `--base <dir>` or `--config <file>`.

- **Imports**  
  - Explicit imports for `KnowledgeBaseError`, `KnowledgeBaseExistsError`, `ConfigurationError`, `RAGInitializationError`, `RAGManagerError` for clearer handling in `run_create_mode` and related code.

### Documentation (`README.md`)

- **Running the tool**  
  - Document both `--config` and `--base` in the main command examples.

- **MCP client configuration**  
  - **Docker (spawn per request):** Example JSON using `docker run --rm -v ... knowledge-mcp` for clients that start the server per request.  
  - **Docker (persistent):** Example with `docker run -d ...` for a long-lived server.

- **New section: Docker setup & usage**  
  - Build image, quick commands (persistent server, one-off `shell` / `create` / `list`), docker-compose usage, and required host setup (`~/kb`, `config.yaml`, `.env`, `knowledge_base.base_dir: /app/kb`).

- **Configuration**  
  - Note that when using Docker, `knowledge_base.base_dir` in the mounted config should be set to `/app/kb`.

- **CLI description**  
  - State that every command requires either `--config <path-to-config.yaml>` or `--base <directory-containing-config.yaml>` (e.g. Docker with `--base /app/kb`).

## Testing

- Built image and ran: default server, `shell`, `create`, `list` with a volume mount.  
- Confirmed `--base /app/kb` and `--config /app/kb/config.yaml` both work before subcommands.  
- Dev container: verified container starts and Docker is available inside.

## Backward compatibility

- All existing invocations that use `--config <path>` remain valid.  
- The default for `--config` is now `None` (no default path); callers must pass either `--config` or `--base`. This makes the contract explicit and avoids silent use of a missing `config.yml` in new environments (e.g. Docker). If you prefer to keep a default path for local use, we can add it back (e.g. `config.yaml` in the current directory) while still supporting `--base`.
